### PR TITLE
feat: use ulid json converter property name converters

### DIFF
--- a/StrictId/Json/IdJsonConverter.cs
+++ b/StrictId/Json/IdJsonConverter.cs
@@ -18,6 +18,17 @@ public class IdJsonConverter : JsonConverter<Id>
 
 	public override void Write (Utf8JsonWriter writer, Id value, JsonSerializerOptions options) =>
 		_ulidJsonConverter.Write(writer, value.Value, options);
+	
+	public override void WriteAsPropertyName(Utf8JsonWriter writer, Id value, JsonSerializerOptions options)
+	{
+		_ulidJsonConverter.WriteAsPropertyName(writer, value.Value, options);
+	}
+
+	public override Id ReadAsPropertyName(ref Utf8JsonReader reader, Type typeToConvert,
+		JsonSerializerOptions options)
+	{
+		return new(_ulidJsonConverter.ReadAsPropertyName(ref reader, typeToConvert, options));
+	}
 }
 
 public class IdTypedJsonConverterFactory : JsonConverterFactory
@@ -39,5 +50,16 @@ public class IdTypedJsonConverterFactory : JsonConverterFactory
 
 		public override void Write (Utf8JsonWriter writer, Id<T> value, JsonSerializerOptions options) =>
 			_ulidJsonConverter.Write(writer, value.Value, options);
+		
+		public override void WriteAsPropertyName(Utf8JsonWriter writer, Id<T> value, JsonSerializerOptions options)
+        {
+            _ulidJsonConverter.WriteAsPropertyName(writer, value.Value, options);
+        }
+
+        public override Id<T> ReadAsPropertyName(ref Utf8JsonReader reader, Type typeToConvert,
+            JsonSerializerOptions options)
+        {
+            return new(_ulidJsonConverter.ReadAsPropertyName(ref reader, typeToConvert, options));
+        }
 	}
 }


### PR DESCRIPTION
Currently when serialising StrictIds as a dictionary key, it will error with the following error:

```
The type 'StrictId.Id' is not a supported dictionary key using converter of type 'StrictId.Json.IdJsonConverter'.
```

This PR adds the required `WriteAsPropertyName` and `ReadAsPropertyName` overrides to use the underlying ulid json converter. This changes the error to:

```
Unhandled exception. System.NotSupportedException: The type 'System.Ulid' is not a supported dictionary key using converter of type 'Cysharp.Serialization.Json.UlidJsonConverter'. 
```

However this will be fixed once my PR in the Ulid repository is merged and released: https://github.com/Cysharp/Ulid/pull/68

I manually tested this with a console app:

```csharp
var id = new Id(Ulid.NewUlid());

var dictionary = new Dictionary<Id, string>
{
    { id, "Hello" }
};

Console.WriteLine(JsonSerializer.Serialize(dictionary)); // throws
```